### PR TITLE
Updated to Maya 2022, python <= 3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Maya-Drop-to-Floor
 Maya python script to drop objects to the ground with an optional offset value
 
-1.Place dropToFloor.py into the Maya scripts folder,
-2.Paste the code below in your python Script Editor
-
+1. Place dropToFloor.py into the Maya scripts folder,
+2. Paste the code below in your python Script Editor
+```python
 import dropToFloor
-reload(dropToFloor)
+import imp
+imp.reload(dropToFloor)
 dropToFloor.Window()
-
-3.Click "Save Script to Shell" in the Script Editor menu bar to save this script in your shellf
+```
+3. Click "Save Script to Shell" in the Script Editor menu bar to save this script in your shellf
 
 ![Alt text](dropToFloor.png?raw=true "dropToFloor.png")

--- a/dropToFloor.py
+++ b/dropToFloor.py
@@ -5,7 +5,8 @@
 2.Paste the code below in your python Script Editor
 
 import dropToFloor
-reload(dropToFloor)
+import imp
+imp.reload(dropToFloor)
 dropToFloor.Window()
 
 3.Click "Save Script to Shell" in the Script Editor menu bar to save this script in your shellf


### PR DESCRIPTION
Just updated the code to work with python > 2 <= 3.3, apparently the one used by Maya in 2022.